### PR TITLE
SPI-expose the health export

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -28,7 +28,7 @@ jobs:
         config: [Debug, Release]
         platform:
           - name: iOS
-            destination: 'platform=iOS Simulator,name=iPhone 16 Pro'
+            destination: 'platform=iOS Simulator,name=iPhone 17 Pro'
       fail-fast: false
     with:
       runsonlabels: '["macOS", "self-hosted"]'
@@ -45,7 +45,7 @@ jobs:
         config: [Debug, Release]
         platform:
           - name: iOS
-            destination: 'platform=iOS Simulator,name=iPhone 16 Pro'
+            destination: 'platform=iOS Simulator,name=iPhone 17 Pro'
       fail-fast: false
     with:
       runsonlabels: '["macOS", "self-hosted"]'

--- a/Sources/SpeziOneSecInterface/SpeziOneSecModule.swift
+++ b/Sources/SpeziOneSecInterface/SpeziOneSecModule.swift
@@ -74,6 +74,11 @@ open class SpeziOneSecModule: NSObject, Sendable {
     open func updateState(_ newState: State) {
         state = newState
     }
+    
+    @_spi(TestingSupport)
+    open func triggerHealthExport() async throws {
+        fatalError("implemented in SpeziOneSec")
+    }
 }
 
 

--- a/Sources/SpeziOneSecInterface/SpeziOneSecModule.swift
+++ b/Sources/SpeziOneSecInterface/SpeziOneSecModule.swift
@@ -76,7 +76,7 @@ open class SpeziOneSecModule: NSObject, Sendable {
     }
     
     @_spi(APISupport)
-    open func triggerHealthExport() async throws {
+    open func triggerHealthExport(forceSessionReset: Bool) async throws {
         fatalError("implemented in SpeziOneSec")
     }
 }

--- a/Sources/SpeziOneSecInterface/SpeziOneSecModule.swift
+++ b/Sources/SpeziOneSecInterface/SpeziOneSecModule.swift
@@ -75,7 +75,7 @@ open class SpeziOneSecModule: NSObject, Sendable {
         state = newState
     }
     
-    @_spi(TestingSupport)
+    @_spi(APISupport)
     open func triggerHealthExport() async throws {
         fatalError("implemented in SpeziOneSec")
     }


### PR DESCRIPTION
# SPI-expose the health export

## :recycle: Current situation & Problem
this PR adds an `@_spi(APISupport) open func triggerHeatlthExport() async throws`, which makes the "start the HealthKit export" functionality an (SPI-guarded) part of the SpeziOneSec interface. the motivation here is that this allows testing just the health export without having to go through the survey flow every time.


## :gear: Release Notes
- added `@_spi(APISupport) open func triggerHeatlthExport() async throws` to `SpeziOneSecModule`.


## :books: Documentation
n/a


## :white_check_mark: Testing
n/a

### Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).
