### PR TITLE
Improved states based on survey flow

### DIFF
--- a/Sources/SpeziOneSecInterface/SpeziOneSecModule.swift
+++ b/Sources/SpeziOneSecInterface/SpeziOneSecModule.swift
@@ -28,15 +28,18 @@ public import UIKit
 @MainActor
 open class SpeziOneSecModule: NSObject, Sendable {
     public enum State: Int, Hashable, Codable, Sendable {
-        /// The Spezi one sec integration is, for whatever reason, not available.
+        /// The study is not available for this user.
+        /// This may occur if the user has been deemed ineligible (e.g., underage)
+        /// based on information from a previous survey attempt or other eligibility criteria.
         case unavailable
-        /// The Spezi one sec integration is available, but hasn't yet been initiated.
+        /// The study is available but has not yet been initiated.
         case available
-        /// The Spezi one sec integration is currently being initiated.
-        case initiating
-        /// The Spezi one sec integration is currently active.
+        /// The study was started by the participant, but they indicated being underage.
+        /// The study is currently on hold until a parent or guardian provides consent.
+        case awaitingParentalConsent
+        /// The study is currently active.
         case active
-        /// The Spezi one sec integration has been completed.
+        /// The study has been completed.
         case completed
     }
     


### PR DESCRIPTION
# Improved states based on survey flow

## :recycle: Current situation & Problem
Not all possible states of the survey flow were present in the `SpeziOneSecModule.State` as discussed on Slack.


## :gear: Release Notes
- Removed `.initiating` state
- Added `awaitingParentalConsent` state


### Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [X] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).
